### PR TITLE
latest update UTC date in fetch_by_name/id/all

### DIFF
--- a/diavlos/src/service/service.py
+++ b/diavlos/src/service/service.py
@@ -3,6 +3,9 @@ import logging
 import mwclient
 import re
 
+from time import mktime
+from datetime import datetime
+
 from mwtemplates import TemplateEditor
 
 from .error import ServiceErrorCode as ErrorCode
@@ -205,6 +208,8 @@ class Service:
             page = page.resolve_redirect()
             page_name = page.page_title
             page_full_name = page.name
+            current_revision = page.revisions(limit=1,dir='older').next()
+            latest_update_date=datetime.utcfromtimestamp(mktime(current_revision['timestamp'])).isoformat()
             service_dict = self._service_dict(
                 page_name, page_full_name, TemplateEditor(page.text()))
             if fetch_bpmn_digital_steps is None:
@@ -214,6 +219,9 @@ class Service:
                     digital_steps=fetch_bpmn_digital_steps).xml(
                     service_dict).replace('\n', '').replace(
                     '\t', '').replace('\"', '\'')
+
+            data = {**data, **{"update":latest_update_date}}
+
             result = data
         else:
             result = ErrorCode.NOT_FOUND


### PR DESCRIPTION
On object returns a new attribute `update` with the latest revision time in ISO-8601 UTC format from MediaWiki.
Τhat will help the API consumers to determine when a service is changed on EMD.

```
   ......
         },
          "fullname": "ΥΕ:120 δόσεις εργοδοτών",
          "name": "120 δόσεις εργοδοτών",
          "update": "2021-04-20T08:23:15"
        },
   ......
```
