### PR TITLE
Returns the id of the service as with the name

### DIFF
--- a/diavlos/src/service/service.py
+++ b/diavlos/src/service/service.py
@@ -3,6 +3,9 @@ import logging
 import mwclient
 import re
 
+from time import mktime
+from datetime import datetime
+
 from mwtemplates import TemplateEditor
 
 from .error import ServiceErrorCode as ErrorCode
@@ -205,6 +208,8 @@ class Service:
             page = page.resolve_redirect()
             page_name = page.page_title
             page_full_name = page.name
+            current_revision = page.revisions(limit=1,dir='older').next()
+            latest_update_date=datetime.utcfromtimestamp(mktime(current_revision['timestamp'])).isoformat()
             service_dict = self._service_dict(
                 page_name, page_full_name, TemplateEditor(page.text()))
             if fetch_bpmn_digital_steps is None:
@@ -214,6 +219,9 @@ class Service:
                     digital_steps=fetch_bpmn_digital_steps).xml(
                     service_dict).replace('\n', '').replace(
                     '\t', '').replace('\"', '\'')
+
+            data = {**data, **{"update":latest_update_date}}
+
             result = data
         else:
             result = ErrorCode.NOT_FOUND

--- a/diavlos/src/service/service.py
+++ b/diavlos/src/service/service.py
@@ -114,6 +114,25 @@ class Service:
                 return other_ns_page, other_ns_page_exists
         return page, page_exists
 
+    def _id_by_fullname(self,name_):
+        property_name = self.TITLE
+        askargs_conditions = f'{property_name}::{name_[3:]}'
+        try:
+            site_response = self._site.get(
+                'askargs', format='json',
+                conditions=askargs_conditions,
+                printouts="process_id|process_uuid")
+        except mwclient.errors.APIError:
+            result = ErrorCode.SITE_API_ERROR
+        else:
+            site_response_results = site_response['query']['results']
+            if len(site_response_results) >= 1:
+                result = site_response['query']['results'][name_]['printouts']['process_id']
+            else:
+                result = None
+
+        return result
+
     def _name_by_id(self, id_, is_uuid=False):
         property_name = self.UUID_PROPERTY_NAME \
             if is_uuid else self.ID_PROPERTY_NAME
@@ -175,9 +194,10 @@ class Service:
                         'categorymembers']
                 ]
             else:
-                services_data = [
-                    category_member['title'].replace(
-                        self.DEFAULT_NAMESPACE_PREFIX, '')
+                services_data = [{
+                    "name":category_member['title'].replace(
+                        self.DEFAULT_NAMESPACE_PREFIX, ''),
+                    "id":self.get_id_by_fullname(category_member['title'])}
                     for category_member in mw_response['query'][
                         'categorymembers']
                 ]
@@ -186,6 +206,21 @@ class Service:
                 'services': services_data
             }
         return result
+    
+    def get_id_by_fullname(self,name):
+        """Get the process id by fullname.
+        Args:
+            name (string): The name of the service.
+        Returns:
+            string: or None if the attribute is not yet set.
+        """
+        id = self._id_by_fullname(name)
+        if id != None :
+           if len(id) == 1:
+              id= id[0]
+           else :
+              id = None   
+        return id
 
     def fetch_by_name(self, name, fetch_bpmn_digital_steps=None):
         """Fetch a service by name.


### PR DESCRIPTION
For endpoint `/services` returns name and id of the service like :
```
 "services": [
      {
        "id": "378487",
        "name": "120 δόσεις εργοδοτών"
      },
      {
        "id": null,
        "name": "120 δόσεις μη μισθωτών και συνταξιούχων"
      },
 ```
 
 if the process_id does not exist or not filled returns null.
 
 That way will be more flexible for API consumers.
 
  